### PR TITLE
Fixed Order Time

### DIFF
--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -3,7 +3,7 @@ import { localTimeStringMilitary } from "../../utils";
 
 const OrdersList = (props) => {
   const { orders } = props;
-  if (!props || !props.orders || !props.orders.length)
+  if (!props || !orders || !orders.length)
     return (
       <div className="empty-orders">
         <h2>There are no orders to display</h2>

--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,32 +1,31 @@
-import React from 'react';
+import React from "react";
+import { localTimeStringMilitary } from "../../utils";
 
 const OrdersList = (props) => {
-    const { orders } = props;
-    if (!props || !props.orders || !props.orders.length) return (
-        <div className="empty-orders">
-            <h2>There are no orders to display</h2>
-        </div>
+  const { orders } = props;
+  if (!props || !props.orders || !props.orders.length)
+    return (
+      <div className="empty-orders">
+        <h2>There are no orders to display</h2>
+      </div>
     );
 
-    return orders.map(order => {
-        const createdDate = new Date(order.createdAt);
-        return (
-            <div className="row view-order-container" key={order._id}>
-                <div className="col-md-4 view-order-left-col p-3">
-                    <h2>{order.order_item}</h2>
-                    <p>Ordered by: {order.ordered_by || ''}</p>
-                </div>
-                <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
-                    <p>Quantity: {order.quantity}</p>
-                </div>
-                <div className="col-md-4 view-order-right-col">
-                    <button className="btn btn-success">Edit</button>
-                    <button className="btn btn-danger">Delete</button>
-                </div>
-            </div>
-        );
-    });
-}
+  return orders.map((order) => (
+    <div className="row view-order-container" key={order._id}>
+      <div className="col-md-4 view-order-left-col p-3">
+        <h2>{order.order_item}</h2>
+        <p>Ordered by: {order.ordered_by || ""}</p>
+      </div>
+      <div className="col-md-4 d-flex view-order-middle-col">
+        <p>Order placed at {localTimeStringMilitary(order.createdAt)}</p>
+        <p>Quantity: {order.quantity}</p>
+      </div>
+      <div className="col-md-4 view-order-right-col">
+        <button className="btn btn-success">Edit</button>
+        <button className="btn btn-danger">Delete</button>
+      </div>
+    </div>
+  ));
+};
 
 export default OrdersList;

--- a/application/src/utils/index.js
+++ b/application/src/utils/index.js
@@ -1,0 +1,3 @@
+import { localTimeStringMilitary } from "./localTimeString";
+
+export { localTimeStringMilitary };

--- a/application/src/utils/localTimeString.js
+++ b/application/src/utils/localTimeString.js
@@ -1,0 +1,16 @@
+/**
+ * Gets the input date and creates a local time string in military format, or
+ * provide no input date which still creates the current local time string in
+ * military format.
+ * @param {String | null} inputDate
+ * @returns {String} A local time string in military format.
+ */
+export const localTimeStringMilitary = (inputDate) => {
+  const localDate = !inputDate ? new Date() : new Date(inputDate);
+
+  const localMilitaryTime = localDate.toLocaleTimeString(undefined, {
+    hour12: false,
+  });
+
+  return localMilitaryTime;
+};


### PR DESCRIPTION
## Changes
1. Created a custom utility function which converts the date into a militarized time zone, and used it to fix the Order Time.

## Purpose
The Order Time should be correctly formatted in `hh:mm:ss` format.

## Approach
In order to correctly display the Order Time, research was done on how to implement it. By understanding and analyzing an article called [_The Definitive Guide to DateTime Manipulation_](https://www.toptal.com/software/definitive-guide-to-datetime-manipulation) by Punit Jajodia on the nature of `DateTime`, an implementation of a utility function was created called `localTimeStringMilitary`. This works by taking the input date, converting it to a locale date, and then convert that locale date into a militarized locale time string. Even if the developer does no input any date, the function would still generate based on the current `DateTime`. This works because no matter what region or location the user is at, it would generate this converted date and output based on the user's current geolocation.

The next step was implementing this utility function into `orderList.js`, and it worked as expected by displaying only double digits even if there was a digit less than 10.

## Testing
1. Pull changes.
2. On the parent directory, run `docker compose up` on your terminal.
3. Go to the `/login` path on your browser and login in.
4. Select the "Order Form" navigation tab and add an order during a time (minutes/seconds) that is less than 10.
5. Select the "View Orders" and find the order you had created.
6. Make sure that the times are in military format without any single digits.

## Screenshots
![Screenshot 2021-09-15](https://user-images.githubusercontent.com/29642735/133536536-da867ba6-1421-48e8-90ad-c69b63d53ce9.png)


## Learning
[The Definitive Guide to DateTime Manipulation](https://www.toptal.com/software/definitive-guide-to-datetime-manipulation).

Closes #2 
Closes #4 