### PR TITLE
Current Orders with Redux

### DIFF
--- a/application/src/components/view-orders-hook/ordersList.js
+++ b/application/src/components/view-orders-hook/ordersList.js
@@ -1,9 +1,13 @@
 import React from "react";
+import { connect } from "react-redux";
 import { localTimeStringMilitary } from "../../utils";
 
-const OrdersList = (props) => {
-  const { orders } = props;
-  if (!props || !orders || !orders.length)
+const mapStateToProps = (state) => ({
+  orders: state.order.orders,
+});
+
+const OrdersList = ({ orders }) => {
+  if (!orders || !orders.length)
     return (
       <div className="empty-orders">
         <h2>There are no orders to display</h2>
@@ -28,4 +32,4 @@ const OrdersList = (props) => {
   ));
 };
 
-export default OrdersList;
+export default connect(mapStateToProps, null)(OrdersList);

--- a/application/src/components/view-orders-hook/viewOrders.js
+++ b/application/src/components/view-orders-hook/viewOrders.js
@@ -1,31 +1,26 @@
-import React, { useState, useEffect } from 'react';
-import { Template } from '../../components';
-import { SERVER_IP } from '../../private';
-import OrdersList from './ordersList';
-import './viewOrders.css';
+import React, { useEffect } from "react";
+import { connect } from "react-redux";
+import { Template } from "../../components";
+import OrdersList from "./ordersList";
+import "./viewOrders.css";
+import { getCurrentOrders } from "../../redux/actions/orderActions";
 
-export default function ViewOrders(props) {
-    const [orders, setOrders] = useState([]);
+const mapDispatchToProps = (dispatch) => ({
+  commenceGetCurrentOrders: () => dispatch(getCurrentOrders()),
+});
 
-    useEffect(() => {
-        fetch(`${SERVER_IP}/api/current-orders`)
-            .then(response => response.json())
-            .then(response => {
-                if(response.success) {
-                    setOrders(response.orders);
-                } else {
-                    console.log('Error getting orders');
-                }
-            });
-    }, [])
+const ViewOrders = ({ commenceGetCurrentOrders }) => {
+  useEffect(() => {
+    commenceGetCurrentOrders();
+  }, []);
 
-    return (
-        <Template>
-            <div className="container-fluid">
-                <OrdersList
-                    orders={orders}
-                />
-            </div>
-        </Template>
-    );
-}
+  return (
+    <Template>
+      <div className="container-fluid">
+        <OrdersList />
+      </div>
+    </Template>
+  );
+};
+
+export default connect(null, mapDispatchToProps)(ViewOrders);

--- a/application/src/redux/actions/orderActions.js
+++ b/application/src/redux/actions/orderActions.js
@@ -1,6 +1,24 @@
-import { ADD_ORDER } from "./types";
+import { ADD_ORDER, GET_CURRENT_ORDERS } from "./types";
 import { SERVER_IP } from "../../private";
 
+// GET CURRENT ORDERS
+const finishGetCurrentOrders = (orders) => ({
+  type: GET_CURRENT_ORDERS,
+  payload: { orders },
+});
+
+export const getCurrentOrders = () => (dispatch) =>
+  fetch(`${SERVER_IP}/api/current-orders`, {
+    method: "GET",
+  })
+    .then((res) => res.json())
+    .then((res) => {
+      if (res.success) {
+        dispatch(finishGetCurrentOrders(res.orders));
+      }
+    });
+
+// ADD ORDER
 const finishAddOrder = (
   _id,
   order_item,

--- a/application/src/redux/actions/types.js
+++ b/application/src/redux/actions/types.js
@@ -1,4 +1,5 @@
 export const LOGIN = "login";
 export const LOGOUT = "logout";
 
+export const GET_CURRENT_ORDERS = "orders/current";
 export const ADD_ORDER = "orders/add";

--- a/application/src/redux/reducers/orderReducer.js
+++ b/application/src/redux/reducers/orderReducer.js
@@ -1,4 +1,4 @@
-import { ADD_ORDER } from "../actions/types";
+import { ADD_ORDER, GET_CURRENT_ORDERS } from "../actions/types";
 
 const INITIAL_STATE = {
   orders: [],
@@ -6,6 +6,11 @@ const INITIAL_STATE = {
 
 const orderReducer = (state = INITIAL_STATE, action) => {
   switch (action.type) {
+    case GET_CURRENT_ORDERS:
+      return {
+        ...state,
+        orders: action.payload.orders,
+      };
     case ADD_ORDER:
       const newOrder = {
         _id: action.payload["_id"],


### PR DESCRIPTION
## Changes
1. Created type, reducer, and action for getting Current Orders in order to fully implement redux and reduce code, and refactored `ordersList.js` and `viewOrders.js` with redux.

## Purpose
There should be a redux implementation for getting all Current Orders from the `orders` API.

## Approach
Since the redux implementation for the `orders` API was implemented for Adding Orders, the same was created for getting all Current Orders. This would be the main reducer hitting the most as the user enters the `/view-orders` URL after logging in.

With the redux created, both `viewOrders.js` and `ordersList.js` was relying on getting and displaying all of the Current Orders, and so those two files were refactored to implement the store from redux which in turn simplifies the lines of code making it easier to read.

## Testing
1. Pull changes.
2. On the parent directory, run `docker compose up` on your terminal.
3. Go to the `/login` path on your browser and login in.
4. If there are any orders, make sure they are being rendered to the `/view-orders` path.
5. Select the "Order Form" navigation tab and add an order.
6. Select the "View Orders" and make sure your order is being rendered.

Closes #16 