### PR TITLE
Log Out with React-Router-Dom and Redux

### DIFF
--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -1,27 +1,39 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { connect } from "react-redux";
+import { Link, useHistory } from "react-router-dom";
+import { logoutUser } from "../../redux/actions/authActions";
 import "./nav.css";
 
-const Nav = (props) => {
-    return (
-        <div className="nav-strip">
-            <Link to={"/order"} className="nav-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">Order Form</label>
-                </div>
-            </Link>
-            <Link to={"/view-orders"} className="nav-link" id="middle-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">View Orders</label>
-                </div>
-            </Link>
-            <Link to={"/login"} className="nav-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">Log Out</label>
-                </div>
-            </Link>
-        </div>
-    );
-}
+const mapDispatchToProps = (dispatch) => ({
+  commenceLogoutUser: () => dispatch(logoutUser()),
+});
 
-export default Nav;
+const Nav = ({ commenceLogoutUser }) => {
+  const history = useHistory();
+
+  const logoutOnClick = () => {
+    commenceLogoutUser();
+    history.replace("/");
+  };
+
+  return (
+    <div className="nav-strip">
+      <Link to={"/order"} className="nav-link">
+        <div className="nav-link-style">
+          <label className="nav-label">Order Form</label>
+        </div>
+      </Link>
+      <Link to={"/view-orders"} className="nav-link" id="middle-link">
+        <div className="nav-link-style">
+          <label className="nav-label">View Orders</label>
+        </div>
+      </Link>
+      <button className="btn btn-link nav-link" onClick={() => logoutOnClick()}>
+        <div className="nav-link-style">
+          <label className="nav-label">Log Out</label>
+        </div>
+      </button>
+    </div>
+  );
+};
+export default connect(null, mapDispatchToProps)(Nav);


### PR DESCRIPTION
## Changes
1. Changed the log out link to a `button` element with added `classNames` to make it look like a Bootstrap `nav-link`.
2. Created an `onClick` function handler that handles the logging out functionality with redux and react-router-dom.

## Purpose
The log out button in the nav should return the user to the welcome page and clear the login information in redux.

## Approach
The change was to simply replace the log out `Link` to a `button` element so that it could properly handle logging out the user by clearing out the user's details with Redux. In  Along with this `onClick` handler, the user would be redirected to the "Welcome" page, and if the user tries to use the back button on their browser, it would not take them back to where they were previously due to using the `replace` method in `useHistory`.

Additionally, to make it look like a "link", the `button` element was added with Bootstrap classes of `btn btn-link`.

## Testing
1. Pull changes.
2. On the parent directory, run docker compose up on your terminal.
3. On the `/login` path, login in which would redirect you to the `/view-orders` path.
4. Hit the "Logout" option from the navbar and make sure you are redirected to the welcome page.
5. Hit the back button on your browser and make sure you are not back to `/view-orders`.

## Screenshots
![eg-5-logout](https://user-images.githubusercontent.com/29642735/134047325-1a5a226d-1f9d-4763-b7e8-878317f56569.gif)


Closes #5 
